### PR TITLE
Add Spamhaus DROP list

### DIFF
--- a/spamhaus-drop-list.txt
+++ b/spamhaus-drop-list.txt
@@ -1,0 +1,7 @@
+# Title: Spamhaus DROP List
+# Description: The Spamhaus Don't Route Or Peer (DROP) list of hijacked or leased netblocks used by professional spam or cyber-crime operations.
+# Homepage: https://www.spamhaus.org/drop/
+# License: https://www.spamhaus.org/legal/terms-of-use/
+# Original Author: The Spamhaus Project
+
+@https://www.spamhaus.org/drop/drop.txt


### PR DESCRIPTION
This PR adds the "Spamhaus DROP list" (https://www.spamhaus.org/drop/) as an external target list. The DROP list consists of netblocks that are hijacked or leased by professional cyber-crime operations (used for dissemination of malware, trojan downloaders, botnet controllers).