### PR TITLE
Create Dandelion-Sprout-Anti-Malware.txt

### DIFF
--- a/Dandelion-Sprout-Anti-Malware.txt
+++ b/Dandelion-Sprout-Anti-Malware.txt
@@ -1,0 +1,6 @@
+# Title: Dandelion Sprout's Anti-Malware List (Domains list version)
+# Description: his list goes the extra kilometer to prevent more malware than other mainstream anti-malware lists. It blocks domains and domain patterns used in malware redirection trains and in domain parking schemes, blocks sponsored Windows PUP nags on PC guide articles, uses mass blocking of domains belonging to bad IPs, and has many other subcategories that give it a solid advantage over similar lists out there.
+# Homepage: https://github.com/DandelionSprout/adfilt/blob/master/Wiki/General-info.md#-english
+# License: https://github.com/DandelionSprout/Dandelicence
+# Original Author: Imre Eilertsen 
+@https://https://raw.githubusercontent.com/DandelionSprout/adfilt/refs/heads/master/Alternate%20versions%20Anti-Malware%20List/AntiMalwareDomains.txt

--- a/Dandelion-Sprout-Anti-Malware.txt
+++ b/Dandelion-Sprout-Anti-Malware.txt
@@ -3,4 +3,4 @@
 # Homepage: https://github.com/DandelionSprout/adfilt/blob/master/Wiki/General-info.md#-english
 # License: https://github.com/DandelionSprout/Dandelicence
 # Original Author: Imre Eilertsen 
-@https://https://raw.githubusercontent.com/DandelionSprout/adfilt/refs/heads/master/Alternate%20versions%20Anti-Malware%20List/AntiMalwareDomains.txt
+@https://raw.githubusercontent.com/DandelionSprout/adfilt/refs/heads/master/Alternate%20versions%20Anti-Malware%20List/AntiMalwareDomains.txt


### PR DESCRIPTION
# Title: Dandelion Sprout's Anti-Malware List (Domains list version)
# Description: This list goes the extra kilometer to prevent more malware than other mainstream anti-malware lists. It blocks domains and domain patterns used in malware redirection trains and in domain parking schemes, blocks sponsored Windows PUP nags on PC guide articles, uses mass blocking of domains belonging to bad IPs, and has many other subcategories that give it a solid advantage over similar lists out there.
# Homepage: https://github.com/DandelionSprout/adfilt/blob/master/Wiki/General-info.md#-english
# License: https://github.com/DandelionSprout/Dandelicence
# Original Author: Imre Eilertsen 
@https://raw.githubusercontent.com/DandelionSprout/adfilt/refs/heads/master/Alternate%20versions%20Anti-Malware%20List/AntiMalwareDomains.txt