### PR TITLE
Change hagezi list to wildcard version

### DIFF
--- a/Hagezi-Multi-Light.txt
+++ b/Hagezi-Multi-Light.txt
@@ -3,4 +3,4 @@
 # Homepage: https://github.com/hagezi/dns-blocklists?tab=readme-ov-file#light
 # License: https://github.com/hagezi/dns-blocklists/blob/main/LICENSE
 # Original Author: Hagezi
-@https://gitlab.com/hagezi/mirror/-/raw/main/dns-blocklists/domains/light.txt
+@https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/wildcard/light.txt

--- a/Hagezi-Multi-Normal.txt
+++ b/Hagezi-Multi-Normal.txt
@@ -3,4 +3,4 @@
 # Homepage: https://github.com/hagezi/dns-blocklists?tab=readme-ov-file#normal
 # License: https://github.com/hagezi/dns-blocklists/blob/main/LICENSE
 # Original Author: Hagezi
-@https://gitlab.com/hagezi/mirror/-/raw/main/dns-blocklists/domains/multi.txt
+@https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/wildcard/multi.txt

--- a/Hagezi-Multi-Ultimate.txt
+++ b/Hagezi-Multi-Ultimate.txt
@@ -3,4 +3,4 @@
 # Homepage: https://github.com/hagezi/dns-blocklists#ultimate
 # License: https://github.com/hagezi/dns-blocklists/blob/main/LICENSE
 # Original Author: Hagezi
-@https://gitlab.com/hagezi/mirror/-/raw/main/dns-blocklists/domains/ultimate.txt
+@https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/wildcard/ultimate.txt

--- a/Hagezi-threat-intelligence-feeds.txt
+++ b/Hagezi-threat-intelligence-feeds.txt
@@ -3,4 +3,4 @@
 # Homepage: https://github.com/hagezi/dns-blocklists#tif
 # License: https://github.com/hagezi/dns-blocklists/blob/main/LICENSE
 # Original Author: Hagezi
-@https://gitlab.com/hagezi/mirror/-/raw/main/dns-blocklists/domains/tif.txt
+@https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/wildcard/tif.txt


### PR DESCRIPTION
The hagezi domain list url will not be further updated after Aug 1. Need to change the source url to wildcard version