### PR TITLE
Add additional HaGeZi blocklists

### DIFF
--- a/Hagezi-Anti-Piracy.txt
+++ b/Hagezi-Anti-Piracy.txt
@@ -1,0 +1,6 @@
+# Title: HaGeZi's Anti-Piracy - blocks piracy sites!
+# Description: Blocks sites and services mainly used for illegally distributing copyrighted content.
+# Homepage: https://github.com/hagezi/dns-blocklists
+# License: https://github.com/hagezi/dns-blocklists/blob/main/LICENSE
+# Original Author: Hagezi
+@https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/wildcard/anti.piracy-onlydomains.txt

--- a/Hagezi-Anti-Piracy.txt
+++ b/Hagezi-Anti-Piracy.txt
@@ -3,4 +3,4 @@
 # Homepage: https://github.com/hagezi/dns-blocklists
 # License: https://github.com/hagezi/dns-blocklists/blob/main/LICENSE
 # Original Author: Hagezi
-@https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/wildcard/anti.piracy-onlydomains.txt
+@https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/wildcard/anti.piracy.txt

--- a/Hagezi-DoH-VPN-Proxy-Bypass.txt
+++ b/Hagezi-DoH-VPN-Proxy-Bypass.txt
@@ -1,0 +1,6 @@
+# Title: HaGeZi's Encrypted DNS/VPN/TOR/Proxy Bypass - stop people from sneaking around your DNS!
+# Description: Prevent methods to bypass your DNS, blocks encrypted DNS, VPN, TOR, Proxies.
+# Homepage: https://github.com/hagezi/dns-blocklists
+# License: https://github.com/hagezi/dns-blocklists/blob/main/LICENSE
+# Original Author: Hagezi
+@https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/wildcard/doh-vpn-proxy-bypass-onlydomains.txt

--- a/Hagezi-DoH-VPN-Proxy-Bypass.txt
+++ b/Hagezi-DoH-VPN-Proxy-Bypass.txt
@@ -3,4 +3,4 @@
 # Homepage: https://github.com/hagezi/dns-blocklists
 # License: https://github.com/hagezi/dns-blocklists/blob/main/LICENSE
 # Original Author: Hagezi
-@https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/wildcard/doh-vpn-proxy-bypass-onlydomains.txt
+@https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/wildcard/doh-vpn-proxy-bypass.txt

--- a/Hagezi-Dynamic-DNS.txt
+++ b/Hagezi-Dynamic-DNS.txt
@@ -3,4 +3,4 @@
 # Homepage: https://github.com/hagezi/dns-blocklists
 # License: https://github.com/hagezi/dns-blocklists/blob/main/LICENSE
 # Original Author: Hagezi
-@https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/wildcard/dyndns-onlydomains.txt
+@https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/wildcard/dyndns.txt

--- a/Hagezi-Dynamic-DNS.txt
+++ b/Hagezi-Dynamic-DNS.txt
@@ -1,0 +1,6 @@
+# Title: HaGeZi's DynDNS - guards against dynamic DNS abuse!
+# Description: Blocks dynamic DNS services that get abused for phishing campaigns and other shady activity.
+# Homepage: https://github.com/hagezi/dns-blocklists
+# License: https://github.com/hagezi/dns-blocklists/blob/main/LICENSE
+# Original Author: Hagezi
+@https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/wildcard/dyndns-onlydomains.txt

--- a/Hagezi-URL-Shortener.txt
+++ b/Hagezi-URL-Shortener.txt
@@ -1,0 +1,6 @@
+# Title: HaGeZi's URL Shortener - blocks link shorteners!
+# Description: This list blocks every known URL/link shortener out there.
+# Homepage: https://github.com/hagezi/dns-blocklists
+# License: https://github.com/hagezi/dns-blocklists/blob/main/LICENSE
+# Original Author: Hagezi
+@https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/wildcard/urlshortener-onlydomains.txt

--- a/Hagezi-URL-Shortener.txt
+++ b/Hagezi-URL-Shortener.txt
@@ -3,4 +3,4 @@
 # Homepage: https://github.com/hagezi/dns-blocklists
 # License: https://github.com/hagezi/dns-blocklists/blob/main/LICENSE
 # Original Author: Hagezi
-@https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/wildcard/urlshortener-onlydomains.txt
+@https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/wildcard/urlshortener.txt


### PR DESCRIPTION
## Summary

Add four additional HaGeZi external blocklists requested by the Firewalla community:

* HaGeZi Encrypted DNS/VPN/TOR/Proxy Bypass
* HaGeZi DynDNS
* HaGeZi URL Shortener
* HaGeZi Anti-Piracy

Each list is represented using the repository's external-list metadata format and points to HaGeZi's domain-only (`wildcard/*-onlydomains.txt`) source.

## Changes

Added:

* `Hagezi-DoH-VPN-Proxy-Bypass.txt`
* `Hagezi-Dynamic-DNS.txt`
* `Hagezi-URL-Shortener.txt`
* `Hagezi-Anti-Piracy.txt`

All entries include the required:

* `Title`
* `Description`
* `Homepage`
* `License`
* `Original Author`

and use the `@` external-list pointer format documented by this repository.

## Related Issues

* Addresses the outstanding HaGeZi list requests in [[#28](https://github.com/firewalla/fw-public-lists/issues/28)](https://github.com/firewalla/fw-public-lists/issues/28)
* Covers the duplicate DoH/VPN/Proxy request from [[#24](https://github.com/firewalla/fw-public-lists/issues/24)](https://github.com/firewalla/fw-public-lists/issues/24)
* The NSFW request from [[#23](https://github.com/firewalla/fw-public-lists/issues/23)](https://github.com/firewalla/fw-public-lists/issues/23) is not duplicated here because `Hagezi-NSFW.txt` is already present.

## Verification

Verified that the branch contains only the four intended new list files and that each external URL corresponds to a current HaGeZi domain-only list.