### PR TITLE
Add ouraidream.com to NSFW AI Blocklist

### DIFF
--- a/nsfw-ai.txt
+++ b/nsfw-ai.txt
@@ -65,6 +65,7 @@
 *.nectar.ai
 *.nomi.ai
 *.nsfwcharacterai.com
+*.ouraidream.com
 *.ourdream.ai
 *.pephop.ai
 *.pirr.ai


### PR DESCRIPTION
## Summary

Add `*.ouraidream.com` to Firewalla's NSFW AI blocklist.

## Changes

* Add `*.ouraidream.com` to `nsfw-ai.txt`.
* No other blocklist entries or metadata are modified.

## Rationale

`ouraidream.com` provides AI-generated adult-oriented content and should be included in the existing NSFW AI blocklist so Firewalla users can block access to the service consistently with other listed domains.

## Testing

* Verified the domain entry follows the existing wildcard-domain format used by `nsfw-ai.txt`.
* No functional code changes are involved.